### PR TITLE
correction du problème d'api qui s'est arrêté

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -4,38 +4,36 @@ from fastapi import FastAPI
 from pathlib import Path
 import skops.io as sio
 import logging
+import mlflow
 
 from src.data.make_dataset import get_movies_details, clean_dataset
 
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    format="{asctime} - {levelname} - {message}",
+    style="{",
+    datefmt="%Y-%m-%d %H:%M",
+    level=logging.DEBUG,
+    handlers=[logging.FileHandler("api.log"), logging.StreamHandler()],
 )
-logger = logging.getLogger("api-movie")
+
+# Preload model -------------------
+
+logging.info(
+    "Getting model from MLFlow"
+)
+
+model_name = "production"
+model_version = "latest"
+
+model_uri = f"models:/{model_name}/{model_version}"
+model = mlflow.sklearn.load_model(model_uri)
+
+# Preload model -------------------
 
 app = FastAPI(
     title="Prédiction du revenu d'un film",
     description="Application de prédiction du revenu d'un film",
 )
-
-
-MODEL_PATH = Path("models/best_model.skops")
-
-
-def load_model():
-    try:
-        logger.info(
-            f"Tentative de chargement du modèle depuis l'emplacement {MODEL_PATH}"
-        )
-        trusted_types = sio.get_untrusted_types(file=MODEL_PATH)
-        m = sio.load(MODEL_PATH, trusted=trusted_types)
-        logger.info("Modèle chargé.")
-        return m
-    except Exception as e:
-        logger.error(f"Erreur lors du chargement du modèle : {e}")
-        raise e
-
-
-model = load_model()
 
 
 @app.get("/", tags=["Welcome"])

--- a/app/api_large.py
+++ b/app/api_large.py
@@ -5,36 +5,35 @@ import pandas as pd
 from pathlib import Path
 import skops.io as sio
 import logging
+import mlflow
 
 logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    format="{asctime} - {levelname} - {message}",
+    style="{",
+    datefmt="%Y-%m-%d %H:%M",
+    level=logging.DEBUG,
+    handlers=[logging.FileHandler("api.log"), logging.StreamHandler()],
 )
-logger = logging.getLogger("api-movie")
+
+# Preload model -------------------
+
+logging.info(
+    "Getting model from MLFlow"
+)
+
+model_name = "production"
+model_version = "latest"
+
+model_uri = f"models:/{model_name}/{model_version}"
+model = mlflow.sklearn.load_model(model_uri)
+
+
+# Define app -------------------------
 
 app = FastAPI(
     title="Prédiction du revenu d'un film",
     description="Application de prédiction du revenu d'un film",
 )
-
-
-MODEL_PATH = Path("models/best_model.skops")
-
-
-def load_model():
-    try:
-        logger.info(
-            f"Tentative de chargement du modèle depuis l'emplacement {MODEL_PATH}"
-        )
-        trusted_types = sio.get_untrusted_types(file=MODEL_PATH)
-        m = sio.load(MODEL_PATH, trusted=trusted_types)
-        logger.info("Modèle chargé.")
-        return m
-    except Exception as e:
-        logger.error(f"Erreur lors du chargement du modèle : {e}")
-        raise e
-
-
-model = load_model()
 
 
 @app.get("/", tags=["Welcome"])

--- a/app/run.sh
+++ b/app/run.sh
@@ -1,2 +1,1 @@
-uv run train.py
 uv run uvicorn app.api:app --host "0.0.0.0"

--- a/train.py
+++ b/train.py
@@ -20,6 +20,7 @@ Usage::
 
 from __future__ import annotations
 
+import os
 import argparse
 import logging
 from pathlib import Path
@@ -225,6 +226,8 @@ def run(
     logger.info("Dataset ready: %d rows, %d columns", *df.shape)
 
     # -- MLflow experiment -----------------------------------------------------
+    mlflow.set_tracking_uri(os.getenv("MLFLOW_TRACKING_URI"))
+    mlflow.set_experiment(experiment_name)
     mlflow.set_experiment(experiment_name)
 
     with mlflow.start_run(run_name="grid_search_all_models"):


### PR DESCRIPTION
Notre API fonctionnait au moment du dernier push sur Git. Cependant, le groupe qui a fait sa revue de code sur notre code nous a prévenu que l'API ne fonctionnait plus. Nous sommes allés voir sur ARGO et nous nous sommes rendus compte que l'API avait arrêté de fonctionner quelques jours après le rendu. Nous pensons que l'erreur est que l'API utilisait le modèle local et donc si elle se relançait, elle n'avait plus accès à ce modèle et ne fonctionnait plus. Nous utilisions bien mlflow mais pas la version du modèle qui était enregistré directement sur mlflow mais celle qui s'enregistrait en local. Nous avons donc modifié le modèle appelé pour éviter que l'API ne cesse de fonctionner à nouveau. 